### PR TITLE
Migrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,142 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# ignore PyCharm generated files
+.idea/
+
+# ignore project specific outpus and models
+
+# ignore project specifc data outputs for train and test
+
+# ignore folder for Gina
+Gina/
+
+# ignore MacOS generated files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ dmypy.json
 .idea/
 
 # ignore project specific outpus and models
+Pretrain/
 
 # ignore project specifc data outputs for train and test
 

--- a/MLP.py
+++ b/MLP.py
@@ -1,4 +1,9 @@
 '''
+UserWarning: "`binary_crossentropy` received `from_logits=True`, but the `output` argument was produced by a sigmoid or softmax activation and thus does not represent logits. Was this intended?"
+  return dispatch_target(*args, **kwargs)
+'''
+
+'''
 Created on Aug 9, 2016
 Keras Implementation of Multi-Layer Perceptron (GMF) recommender model in:
 He Xiangnan et al. Neural Collaborative Filtering. In WWW 2017.  
@@ -8,23 +13,29 @@ He Xiangnan et al. Neural Collaborative Filtering. In WWW 2017.
 
 import numpy as np
 
-import theano
-import theano.tensor as T
-import keras
-from keras import backend as K
-from keras import initializations
-from keras.regularizers import l2, activity_l2
-from keras.models import Sequential, Graph, Model
-from keras.layers.core import Dense, Lambda, Activation
-from keras.layers import Embedding, Input, Dense, merge, Reshape, Merge, Flatten, Dropout
-from keras.constraints import maxnorm
-from keras.optimizers import Adagrad, Adam, SGD, RMSprop
+import tensorflow
+import tensorflow.keras
+# from tensorflow.keras import backend as K
+from tensorflow.keras import initializers    # In Keras 1 it was called initializations
+from tensorflow.keras.regularizers import L2    # In Keras 1 it was called activity_l2
+# ImportError: cannot import name 'Graph' from 'tensorflow.keras.models'
+# from tensorflow.keras.models import Sequential, Graph, Model
+from tensorflow.keras.models import Model
+# ModuleNotFoundError: No module named 'tensorflow.keras.layers.core'
+# from tensorflow.keras.layers.core import Dense, Lambda, Activation
+from tensorflow.keras.layers import Embedding, Input, Dense, Reshape, Flatten, Dropout
+from tensorflow.keras.layers import concatenate   # In Keras 1 there was merge
+# ImportError: cannot import name 'maxnorm' from 'tensorflow.keras.constraints'
+# from tensorflow.keras.constraints import maxnorm
+from tensorflow.keras.optimizers import Adagrad, Adam, SGD, RMSprop
+from tensorflow.keras.losses import BinaryCrossentropy
 from evaluate import evaluate_model
 from Dataset import Dataset
 from time import time
 import sys
 import argparse
 import multiprocessing as mp
+
 
 #################### Arguments ####################
 def parse_args():
@@ -33,8 +44,8 @@ def parse_args():
                         help='Input data path.')
     parser.add_argument('--dataset', nargs='?', default='ml-1m',
                         help='Choose a dataset.')
-    parser.add_argument('--epochs', type=int, default=100,
-                        help='Number of epochs.')
+    parser.add_argument('--epochs', type=int, default=20,
+                        help='Number of epochs.')     # changed default from 100
     parser.add_argument('--batch_size', type=int, default=256,
                         help='Batch size.')
     parser.add_argument('--layers', nargs='?', default='[64,32,16,8]',
@@ -54,38 +65,38 @@ def parse_args():
     return parser.parse_args()
 
 def init_normal(shape, name=None):
-    return initializations.normal(shape, scale=0.01, name=name)
+    return initializers.normal(shape, scale=0.01, name=name)
 
 def get_model(num_users, num_items, layers = [20,10], reg_layers=[0,0]):
     assert len(layers) == len(reg_layers)
-    num_layer = len(layers) #Number of layers in the MLP
+    num_layer = len(layers)  # Number of layers in the MLP
     # Input variables
     user_input = Input(shape=(1,), dtype='int32', name = 'user_input')
     item_input = Input(shape=(1,), dtype='int32', name = 'item_input')
 
-    MLP_Embedding_User = Embedding(input_dim = num_users, output_dim = layers[0]/2, name = 'user_embedding',
-                                  init = init_normal, W_regularizer = l2(reg_layers[0]), input_length=1)
-    MLP_Embedding_Item = Embedding(input_dim = num_items, output_dim = layers[0]/2, name = 'item_embedding',
-                                  init = init_normal, W_regularizer = l2(reg_layers[0]), input_length=1)   
+    MLP_Embedding_User = Embedding(input_dim = num_users, output_dim = round(layers[0]/2), name = 'user_embedding',
+                                  embeddings_initializer='uniform', embeddings_regularizer = L2(l2=reg_layers[0]), input_length=1)
+    MLP_Embedding_Item = Embedding(input_dim = num_items, output_dim = round(layers[0]/2), name = 'item_embedding',
+                                  embeddings_initializer='uniform', embeddings_regularizer = L2(l2=reg_layers[0]), input_length=1)
     
     # Crucial to flatten an embedding vector!
     user_latent = Flatten()(MLP_Embedding_User(user_input))
     item_latent = Flatten()(MLP_Embedding_Item(item_input))
-    
+
     # The 0-th layer is the concatenation of embedding layers
-    vector = merge([user_latent, item_latent], mode = 'concat')
-    
+    vector = concatenate([user_latent, item_latent])
+
     # MLP layers
-    for idx in xrange(1, num_layer):
-        layer = Dense(layers[idx], W_regularizer= l2(reg_layers[idx]), activation='relu', name = 'layer%d' %idx)
+    for idx in range(1, num_layer):
+        layer = Dense(layers[idx], kernel_regularizer= L2(l2=reg_layers[idx]), activation='relu', name = 'layer%d' %idx)
         vector = layer(vector)
-        
+
     # Final prediction layer
-    prediction = Dense(1, activation='sigmoid', init='lecun_uniform', name = 'prediction')(vector)
-    
-    model = Model(input=[user_input, item_input], 
-                  output=prediction)
-    
+    prediction = Dense(1, activation='sigmoid', kernel_initializer=initializers.LecunUniform(), name = 'prediction')(vector)
+
+    model = Model(inputs=[user_input, item_input],
+                  outputs=prediction)
+
     return model
 
 def get_train_instances(train, num_negatives):
@@ -97,9 +108,9 @@ def get_train_instances(train, num_negatives):
         item_input.append(i)
         labels.append(1)
         # negative instances
-        for t in xrange(num_negatives):
+        for t in range(num_negatives):
             j = np.random.randint(num_items)
-            while train.has_key((u, j)):
+            while (u, j) in train.keys():     # while train.has_key((u, j)):
                 j = np.random.randint(num_items)
             user_input.append(u)
             item_input.append(j)
@@ -129,44 +140,44 @@ if __name__ == '__main__':
     dataset = Dataset(args.path + args.dataset)
     train, testRatings, testNegatives = dataset.trainMatrix, dataset.testRatings, dataset.testNegatives
     num_users, num_items = train.shape
-    print("Load data done [%.1f s]. #user=%d, #item=%d, #train=%d, #test=%d" 
+    print("Load data done [%.1f s]. #user=%d, #item=%d, #train=%d, #test=%d"
           %(time()-t1, num_users, num_items, train.nnz, len(testRatings)))
     
     # Build model
     model = get_model(num_users, num_items, layers, reg_layers)
-    if learner.lower() == "adagrad": 
-        model.compile(optimizer=Adagrad(lr=learning_rate), loss='binary_crossentropy')
+    if learner.lower() == "adagrad":
+        model.compile(optimizer=Adagrad(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=True))
     elif learner.lower() == "rmsprop":
-        model.compile(optimizer=RMSprop(lr=learning_rate), loss='binary_crossentropy')
+        model.compile(optimizer=RMSprop(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=True))
     elif learner.lower() == "adam":
-        model.compile(optimizer=Adam(lr=learning_rate), loss='binary_crossentropy')
+        model.compile(optimizer=Adam(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=True))
     else:
-        model.compile(optimizer=SGD(lr=learning_rate), loss='binary_crossentropy')    
-    
+        model.compile(optimizer=SGD(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=True))
+
     # Check Init performance
     t1 = time()
     (hits, ndcgs) = evaluate_model(model, testRatings, testNegatives, topK, evaluation_threads)
     hr, ndcg = np.array(hits).mean(), np.array(ndcgs).mean()
     print('Init: HR = %.4f, NDCG = %.4f [%.1f]' %(hr, ndcg, time()-t1))
-    
+
     # Train model
     best_hr, best_ndcg, best_iter = hr, ndcg, -1
-    for epoch in xrange(epochs):
+    for epoch in range(epochs):
         t1 = time()
         # Generate training instances
         user_input, item_input, labels = get_train_instances(train, num_negatives)
-    
-        # Training        
+
+        # Training
         hist = model.fit([np.array(user_input), np.array(item_input)], #input
-                         np.array(labels), # labels 
-                         batch_size=batch_size, nb_epoch=1, verbose=0, shuffle=True)
+                         np.array(labels), # labels
+                         batch_size=batch_size, epochs=1, verbose=0, shuffle=True)
         t2 = time()
 
         # Evaluation
         if epoch %verbose == 0:
             (hits, ndcgs) = evaluate_model(model, testRatings, testNegatives, topK, evaluation_threads)
             hr, ndcg, loss = np.array(hits).mean(), np.array(ndcgs).mean(), hist.history['loss'][0]
-            print('Iteration %d [%.1f s]: HR = %.4f, NDCG = %.4f, loss = %.4f [%.1f s]' 
+            print('Iteration %d [%.1f s]: HR = %.4f, NDCG = %.4f, loss = %.4f [%.1f s]'
                   % (epoch,  t2-t1, hr, ndcg, loss, time()-t2))
             if hr > best_hr:
                 best_hr, best_ndcg, best_iter = hr, ndcg, epoch

--- a/MLP.py
+++ b/MLP.py
@@ -1,9 +1,4 @@
 '''
-UserWarning: "`binary_crossentropy` received `from_logits=True`, but the `output` argument was produced by a sigmoid or softmax activation and thus does not represent logits. Was this intended?"
-  return dispatch_target(*args, **kwargs)
-'''
-
-'''
 Created on Aug 9, 2016
 Keras Implementation of Multi-Layer Perceptron (GMF) recommender model in:
 He Xiangnan et al. Neural Collaborative Filtering. In WWW 2017.  
@@ -12,29 +7,17 @@ He Xiangnan et al. Neural Collaborative Filtering. In WWW 2017.
 '''
 
 import numpy as np
-
-import tensorflow
-import tensorflow.keras
-# from tensorflow.keras import backend as K
-from tensorflow.keras import initializers    # In Keras 1 it was called initializations
-from tensorflow.keras.regularizers import L2    # In Keras 1 it was called activity_l2
-# ImportError: cannot import name 'Graph' from 'tensorflow.keras.models'
-# from tensorflow.keras.models import Sequential, Graph, Model
-from tensorflow.keras.models import Model
-# ModuleNotFoundError: No module named 'tensorflow.keras.layers.core'
-# from tensorflow.keras.layers.core import Dense, Lambda, Activation
-from tensorflow.keras.layers import Embedding, Input, Dense, Reshape, Flatten, Dropout
-from tensorflow.keras.layers import concatenate   # In Keras 1 there was merge
-# ImportError: cannot import name 'maxnorm' from 'tensorflow.keras.constraints'
-# from tensorflow.keras.constraints import maxnorm
-from tensorflow.keras.optimizers import Adagrad, Adam, SGD, RMSprop
-from tensorflow.keras.losses import BinaryCrossentropy
+from keras import initializers    # In Keras 1 it was called initializations
+from keras.regularizers import L2    # In Keras 1 it was called activity_l2
+from keras.models import Model
+from keras.layers import Embedding, Input, Dense, Flatten
+from keras.layers import concatenate   # In Keras 1 there was merge
+from keras.optimizers import Adagrad, Adam, SGD, RMSprop
+from keras.losses import BinaryCrossentropy
 from evaluate import evaluate_model
 from Dataset import Dataset
 from time import time
-import sys
 import argparse
-import multiprocessing as mp
 
 
 #################### Arguments ####################
@@ -146,13 +129,13 @@ if __name__ == '__main__':
     # Build model
     model = get_model(num_users, num_items, layers, reg_layers)
     if learner.lower() == "adagrad":
-        model.compile(optimizer=Adagrad(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=True))
+        model.compile(optimizer=Adagrad(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=False))
     elif learner.lower() == "rmsprop":
-        model.compile(optimizer=RMSprop(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=True))
+        model.compile(optimizer=RMSprop(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=False))
     elif learner.lower() == "adam":
-        model.compile(optimizer=Adam(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=True))
+        model.compile(optimizer=Adam(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=False))
     else:
-        model.compile(optimizer=SGD(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=True))
+        model.compile(optimizer=SGD(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=False))
 
     # Check Init performance
     t1 = time()

--- a/evaluate.py
+++ b/evaluate.py
@@ -44,7 +44,7 @@ def evaluate_model(model, testRatings, testNegatives, K, num_thread):
         ndcgs = [r[1] for r in res]
         return (hits, ndcgs)
     # Single thread
-    for idx in xrange(len(_testRatings)):
+    for idx in range(len(_testRatings)):
         (hr,ndcg) = eval_one_rating(idx)
         hits.append(hr)
         ndcgs.append(ndcg)      
@@ -61,7 +61,7 @@ def eval_one_rating(idx):
     users = np.full(len(items), u, dtype = 'int32')
     predictions = _model.predict([users, np.array(items)], 
                                  batch_size=100, verbose=0)
-    for i in xrange(len(items)):
+    for i in range(len(items)):
         item = items[i]
         map_item_score[item] = predictions[i]
     items.pop()
@@ -79,7 +79,7 @@ def getHitRatio(ranklist, gtItem):
     return 0
 
 def getNDCG(ranklist, gtItem):
-    for i in xrange(len(ranklist)):
+    for i in range(len(ranklist)):
         item = ranklist[i]
         if item == gtItem:
             return math.log(2) / math.log(i+2)


### PR DESCRIPTION
Migrated MLP.py to Python 3.10.6, Keras 2.9.0, Tensorflow 2.9.1

We might want to look into this warning:
UserWarning: "`binary_crossentropy` received `from_logits=True`, but the `output` argument was produced by a sigmoid or softmax activation and thus does not represent logits. Was this intended?"

I ran it without GPU with the following result:
MLP arguments: Namespace(path='Data/', dataset='ml-1m', epochs=20, batch_size=256, layers='[64,32,16,8]', reg_layers='[0,0,0,0]', num_neg=4, lr=0.001, learner='adam', verbose=1, out=1) 
Load data done [12.6 s]. #user=6040, #item=3706, #train=994169, #test=6040
...
Iteration 14 [48.0 s]: HR = 0.6724, NDCG = 0.3915, loss = 0.2426 [201.8 s]
2022-08-26 14:37:11.016687: F ./tensorflow/core/lib/monitoring/counter.h:198] Check failed: 0 <= step (0 vs. -192756)Must not decrement cumulative metrics.

Process finished with exit code 134 (interrupted by signal 6: SIGABRT)

UPDATE(Aug31): Warning is related to loss selection at MLP.py near line 149
"model.compile(optimizer=Adagrad(learning_rate=learning_rate), loss=BinaryCrossentropy(from_logits=True))" 
The last layer of the model uses a sigmoid:
"prediction = Dense(1, activation='sigmoid', kernel_initializer=initializers.LecunUniform(), name = 'prediction')(vector)"
Turning from_logits to False might resolve the warning. Below a couple of resources
https://www.tensorflow.org/api_docs/python/tf/keras/losses/BinaryCrossentropy
https://keras.io/api/layers/activations/